### PR TITLE
Add an option to disable writing dmrc files

### DIFF
--- a/common/dmrc.c
+++ b/common/dmrc.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "config.h"
 #include "dmrc.h"
 #include "configuration.h"
 #include "privileges.h"
@@ -54,6 +55,7 @@ dmrc_save (GKeyFile *dmrc_file, CommonUser *user)
     gsize length;
     g_autofree gchar *data = g_key_file_to_data (dmrc_file, &length, NULL);
 
+#ifdef WRITE_DMRC
     /* Update the users .dmrc */
     g_autofree gchar *path = g_build_filename (common_user_get_home_directory (user), ".dmrc", NULL);
 
@@ -65,6 +67,7 @@ dmrc_save (GKeyFile *dmrc_file, CommonUser *user)
     g_file_set_contents (path, data, length, NULL);
     if (drop_privileges)
         privileges_reclaim ();
+#endif
 
     /* Update the .dmrc cache */
     g_autofree gchar *cache_dir = config_get_string (config_get_instance (), "LightDM", "cache-directory");

--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,17 @@ AC_MSG_CHECKING(whether to build tests)
 AC_ARG_ENABLE(tests,
         AS_HELP_STRING([--disable-tests], [Disable tests building]),
         [], [enable_tests="yes"])
+AC_MSG_RESULT([$enable_tests])
 AM_CONDITIONAL(COMPILE_TESTS, test x"$enable_tests" != "xno")
+
+AC_MSG_CHECKING(whether to enable writing dmrc files)
+AC_ARG_ENABLE(dmrc,
+        AS_HELP_STRING([--disable-dmrc], [Disable writing .dmrc in user home]),
+        [], [enable_dmrc="yes"])
+AC_MSG_RESULT([$enable_dmrc])
+if test x"$enable_dmrc" != "xno"; then
+  AC_DEFINE([WRITE_DMRC], [1], [Enable writing .dmrc in user home])
+fi
 
 dnl ###########################################################################
 dnl Configurable values
@@ -264,4 +274,5 @@ echo "
         liblightdm-qt5:           $compile_liblightdm_qt5
         libaudit support:         $use_libaudit
         Enable tests:             $enable_tests
+        Write .dmrc files:        $enable_dmrc
 "


### PR DESCRIPTION
This might be needed for some distributions, which are using SELinux.  See: https://bugzilla.redhat.com/show_bug.cgi?id=963238