### PR TITLE
Determine a session is wayland with a better heuristic

### DIFF
--- a/liblightdm-gobject/Makefile.am
+++ b/liblightdm-gobject/Makefile.am
@@ -9,7 +9,6 @@ liblightdm_gobject_1_la_CFLAGS = $(LIBLIGHTDM_GOBJECT_CFLAGS) \
 	-I"$(top_srcdir)/common" \
 	-DCONFIG_DIR=\"$(sysconfdir)/lightdm\" \
 	-DSESSIONS_DIR=\"$(pkgdatadir)/sessions:$(datadir)/xsessions:$(datadir)/wayland-sessions\" \
-	-DWAYLAND_SESSIONS_DIR=\"$(datadir)/wayland-sessions\" \
 	-DREMOTE_SESSIONS_DIR=\"$(pkgdatadir)/remote-sessions\"
 
 mainheader_HEADERS = lightdm.h

--- a/liblightdm-gobject/session.c
+++ b/liblightdm-gobject/session.c
@@ -171,7 +171,7 @@ load_sessions (const gchar *sessions_dir)
     {
         const gchar *default_type = "x";
 
-        if (strcmp (dirs[i], WAYLAND_SESSIONS_DIR) == 0)
+        if (dirs[i] != NULL && g_str_has_suffix (dirs[i], "/wayland-sessions") == TRUE)
             default_type = "wayland";
 
         sessions = load_sessions_dir (sessions, dirs[i], default_type);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,7 +82,6 @@ lightdm_CFLAGS = \
 	-DRUN_DIR=\"$(localstatedir)/run/lightdm\" \
 	-DCACHE_DIR=\"$(localstatedir)/cache/lightdm\" \
 	-DSESSIONS_DIR=\"$(pkgdatadir)/sessions:$(datadir)/xsessions:$(datadir)/wayland-sessions\" \
-	-DWAYLAND_SESSIONS_DIR=\"$(datadir)/wayland-sessions\" \
 	-DREMOTE_SESSIONS_DIR=\"$(pkgdatadir)/remote-sessions\"
 
 lightdm_LDADD = \

--- a/src/seat.c
+++ b/src/seat.c
@@ -956,7 +956,7 @@ find_session_config (Seat *seat, const gchar *sessions_dir, const gchar *session
     for (int i = 0; dirs[i]; i++)
     {
         const gchar *default_session_type = "x";
-        if (strcmp (dirs[i], WAYLAND_SESSIONS_DIR) == 0)
+        if (dirs[i] != NULL && g_str_has_suffix (dirs[i], "/wayland-sessions") == TRUE)
             default_session_type = "wayland";
 
         g_autofree gchar *filename = g_strdup_printf ("%s.desktop", session_name);


### PR DESCRIPTION
Using the compiled in string WAYLAND_SESSIONS_DIR had some problems.
In environments like NixOS, which install packages under their
own immutable prefix under /nix/store. this assumption that the package
would be compiled with `datadir=/usr/share` will break down. Checking
if the directory contains the appropriate string is much simpler and will
work with platforms like NixOS (or others as this setup popularizes).