### PR TITLE
in Remove X authority: Ignore any error & don't exit, continue closin…

### DIFF
--- a/src/session-child.c
+++ b/src/session-child.c
@@ -810,8 +810,7 @@ session_child_run (int argc, char **argv)
         if (error)
             g_printerr ("Error removing X authority: %s\n", error->message);
         g_clear_error (&error);
-        if (!result)
-            _exit (EXIT_FAILURE);
+        /* Ignore this error, don't exit, continue closing the session. */
     }
 
     /* Close the Console Kit session */


### PR DESCRIPTION
…g the session

Same as <https://github.com/canonical/lightdm/pull/13>, which did it into 1.28, but for 1.18 (if it's still alive).