### PR TITLE
Fix: "DesktopManager" -> "DisplayManager"

### DIFF
--- a/data/dm-tool.1
+++ b/data/dm-tool.1
@@ -66,7 +66,7 @@ Used by dm-tool to determine in which display manager session it's running. When
 outside of a display-manager use its
 .B list-seats
 command to show active sessions and set the session to connect to with:
-.B export XDG_SEAT_PATH=/org/freedesktop/DesktopManager/SeatX
+.B export XDG_SEAT_PATH=/org/freedesktop/DisplayManager/SeatX
 where
 .B SeatX
 is one of the listed sessions.


### PR DESCRIPTION
Based on what worked for me; and, uses within this repo, the correct path seems to include "DisplayManager" not "DesktopManager".

The documentation was originally added via https://github.com/canonical/lightdm/pull/28 in order to address https://github.com/canonical/lightdm/issues/27.