### PR TITLE
Glibc 2.33 fix.

### DIFF
--- a/tests/src/libsystem.c
+++ b/tests/src/libsystem.c
@@ -329,6 +329,10 @@ stat64 (const char *path, struct stat64 *buf)
     return _stat64 (new_path, buf);
 }
 
+// glibc 2.33 and newer does not declare these functions in a header file
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+
 int
 __xstat (int version, const char *path, struct stat *buf)
 {
@@ -364,6 +368,8 @@ __fxstatat64(int ver, int dirfd, const char *pathname, struct stat64 *buf, int f
     g_autofree gchar *new_path = redirect_path (pathname);
     return ___fxstatat64 (ver, dirfd, new_path, buf, flags);
 }
+
+#pragma GCC diagnostic pop
 
 DIR *
 opendir (const char *name)


### PR DESCRIPTION
The library does not declare __fxstatat64 and friends in a header file.
Thus the following warning appears:

```
libsystem.c:333:1: error: no previous prototype for '__xstat' [-Werror=missing-prototypes]
  333 | __xstat (int version, const char *path, struct stat *buf)
      | ^~~~~~~
libsystem.c:342:1: error: no previous prototype for '__xstat64' [-Werror=missing-prototypes]
  342 | __xstat64 (int version, const char *path, struct stat64 *buf)
      | ^~~~~~~~~
libsystem.c:351:1: error: no previous prototype for '__fxstatat' [-Werror=missing-prototypes]
  351 | __fxstatat(int ver, int dirfd, const char *pathname, struct stat *buf, int flags)
      | ^~~~~~~~~~
libsystem.c:360:1: error: no previous prototype for '__fxstatat64' [-Werror=missing-prototypes]
  360 | __fxstatat64(int ver, int dirfd, const char *pathname, struct stat64 *buf, int flags)
      | ^~~~~~~~~~~~
```

Fixed #167.