### PR TITLE
Do not print errors when pam_kwallet is not installed

### DIFF
--- a/debian/lightdm.lightdm-greeter.pam
+++ b/debian/lightdm.lightdm-greeter.pam
@@ -1,15 +1,15 @@
 #%PAM-1.0
 auth    required        pam_permit.so
 auth    optional        pam_gnome_keyring.so
-auth    optional        pam_kwallet.so
-auth    optional        pam_kwallet5.so
+-auth    optional        pam_kwallet.so
+-auth    optional        pam_kwallet5.so
 @include common-account
 session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
 session required        pam_limits.so
 @include common-session
 session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
 session optional        pam_gnome_keyring.so auto_start
-session optional        pam_kwallet.so auto_start
-session optional        pam_kwallet5.so auto_start
+-session optional        pam_kwallet.so auto_start
+-session optional        pam_kwallet5.so auto_start
 session required        pam_env.so readenv=1
 session required        pam_env.so readenv=1 user_readenv=1 envfile=/etc/default/locale

--- a/debian/lightdm.pam
+++ b/debian/lightdm.pam
@@ -3,8 +3,8 @@ auth    requisite       pam_nologin.so
 auth    sufficient      pam_succeed_if.so user ingroup nopasswdlogin
 @include common-auth
 auth    optional        pam_gnome_keyring.so
-auth    optional        pam_kwallet.so
-auth    optional        pam_kwallet5.so
+-auth    optional        pam_kwallet.so
+-auth    optional        pam_kwallet5.so
 @include common-account
 session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
 #session required        pam_loginuid.so
@@ -12,8 +12,8 @@ session required        pam_limits.so
 @include common-session
 session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
 session optional        pam_gnome_keyring.so auto_start
-session optional        pam_kwallet.so auto_start
-session optional        pam_kwallet5.so auto_start
+-session optional        pam_kwallet.so auto_start
+-session optional        pam_kwallet5.so auto_start
 session required        pam_env.so readenv=1
 session required        pam_env.so readenv=1 user_readenv=1 envfile=/etc/default/locale
 @include common-password


### PR DESCRIPTION
This fixes Launchpad bug [#1309535](https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/1309535/)

Since kwallet is an optional dependency concerning only KDE users,
tell PAM to not print error messages if the kwallet modules are
not present. This is done simply by prefixing the corresponding
lines with a '-' (dash), as suggested in pam.conf(5).