### PR TITLE
Update x-authority.c

### DIFF
--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -320,7 +320,7 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
 
     /* Write records back */
     errno = 0;
-    int output_fd = g_open (filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+    int output_fd = g_open (filename, O_WRONLY | O_CREAT | O_TRUNC , S_IRUSR | S_IWUSR);
     if (output_fd < 0)
     {
         g_set_error (error,


### PR DESCRIPTION
No O_TRUNC causes the xauthority file corruption.
In case the address of XDMCP DISPLAY length differs.
1st access came from "192.168.1.1:1".
2nd access came from "hostname.com:2".
And close 1st access.
The result of \# xauth -f /var/run/lightdm/lightdm/xauthority list is as follows.
hostname/unix0 MIT-MAGIC-COOKIE-1 xxxxxxxx.
hostname.com:2 MIT-MAGIC-COOKIE-1 yyyyyyyy.

And next access from "192.168.1.2:2"
hostname/unix0 MIT-MAGIC-COOKIE-1 xxxxxxx...x.
hostname.com:2 MIT-MAGIC-COOKIE-1 yyyyy...yyy.
192.168.1.2:2 MIT-MAGIC-COOKIE-1 zzzzzzz...zz.

And close the session from "hostname.com:2" will cause the corruption.
hostname/unix0 MIT-MAGIC-COOKIE-1 xxxxxxx...x.
192.168.1.2:2 MIT-MAGIC-COOKIE-1 zzzzzzz...zz.
#$weq321%  3 44ddaawe3we12312421412z.

This is because, without O_TRUNC will open original file itself, REMOVE will delete the entry of hostname.com:2 , but the length is too big to 192.168.1.2:2.

