### PR TITLE
fix: make x_authority_write work on XAUTH_REMOVE_MODE

### DIFF
--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -320,7 +320,7 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
 
     /* Write records back */
     errno = 0;
-    int output_fd = g_open (filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+    int output_fd = g_open (filename, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (output_fd < 0)
     {
         g_set_error (error,


### PR DESCRIPTION
I found when I switch between users, sometimes there will be multiple Xauthority entries belonging to exactly the same x display.

So I found the code in lightdm which write xauthority to user's home dir. I found when Robert Ancell <robert.ancell@canonical.com> write this code down in 8d667243eb63f3891a49eea2c3495ff50736e069, he use mode O_WRONLY | O_CREAT:
https://github.com/canonical/lightdm/blob/8d667243eb63f3891a49eea2c3495ff50736e069/src/x-authority.c#L318

This is the root cause of this bug, see this example below:

```cpp
#include <fcntl.h>
#include <stdlib.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>

int main() {
  int fd = open("./a.txt", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
  write(fd, "11145", 5);
  fsync(fd);
  close(fd);
  fd = open("./a.txt", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
  write(fd, "123", 3);
  fsync(fd);
  close(fd);
}

```
After running this program, the content of a.txt is `12345`.
so when removing an entry from the old Xauthority file, lightdm currently messing up the file content by leaving the last line untouched.

I add a flag to `g_open` to fix this bug.

`man 2 open` says:
> If the file already exists and is a regular file and the access mode allows writing (i.e., is O_RDWR or O_WRONLY) it will be truncated to length 0.  If the file is a FIFO or terminal device file, the O_TRUNC flag is ignored. Otherwise, the effect of O_TRUNC is unspecified.
