### PR TITLE
Fix a crash issue

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -137,7 +137,10 @@ process_set_env (Process *process, const gchar *name, const gchar *value)
     ProcessPrivate *priv = process_get_instance_private (process);
     g_return_if_fail (process != NULL);
     g_return_if_fail (name != NULL);
-    g_hash_table_insert (priv->env, g_strdup (name), g_strdup (value));
+    if (NULL == value)
+        g_hash_table_insert (priv->env, g_strdup (name), g_strdup (""));
+    else
+        g_hash_table_insert (priv->env, g_strdup (name), g_strdup (value));
 }
 
 const gchar *


### PR DESCRIPTION
Daer maintainer,
       While run command "init 1", a crash issue happens. The call stack is as following
``
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:79
79              addq    $VEC_SIZE, %rdi
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:79
#1  0x00007f519125da11 in __add_to_environ (name=0x55712471f5b0 "XAUTHORITY", value=0x0, combined=combined@entry=0x0, replace=replace@entry=1) at setenv.c:131
#2  0x00007f519125dc1a in __setenv (name=<optimized out>, value=<optimized out>, replace=replace@entry=1) at setenv.c:259
#3  0x0000557122ce7a09 in process_start (process=process@entry=0x5571246fc5b0, block=block@entry=1) at process.c:247
#4  0x0000557122ce9c5b in run_script (seat=seat@entry=0x5571246e3d30, display_server=display_server@entry=0x5571246e9d50, script_name=script_name@entry=0x7f517800a7c0 "/usr/sbin/deepin-fix-xauthority-perm", user=0x7f5178009840)
    at seat.c:404
#5  0x0000557122cec32d in session_stopped_cb (session=0x55712471e100, seat=0x5571246e3d30) at seat.c:780
#6  0x00007f51916ea286 in  () at /usr/lib64/libgobject-2.0.so.0
#7  0x00007f5191708165 in g_signal_emit_valist () at /usr/lib64/libgobject-2.0.so.0
#8  0x00007f51917087cf in g_signal_emit () at /usr/lib64/libgobject-2.0.so.0
#9  0x0000557122ceeccf in session_watch_cb (pid=<optimized out>, status=<optimized out>, data=0x55712471e100) at session.c:497
#10 0x00007f51915f62e4 in  () at /usr/lib64/libglib-2.0.so.0
#11 0x00007f51915fa064 in g_main_context_dispatch () at /usr/lib64/libglib-2.0.so.0
#12 0x00007f51915fa400 in  () at /usr/lib64/libglib-2.0.so.0
#13 0x00007f51915fa6c2 in g_main_loop_run () at /usr/lib64/libglib-2.0.so.0
#14 0x0000557122cdc760 in main (argc=<optimized out>, argv=<optimized out>) at lightdm.c:915
``

    I try to fix and verify it, Could U please review it
    Thanks