### PR TITLE
Avoid race condition between graphics driver and lightdm

### DIFF
--- a/data/lightdm.conf
+++ b/data/lightdm.conf
@@ -26,7 +26,7 @@
 #lock-memory=true
 #user-authority-in-system-dir=false
 #guest-account-script=guest-account
-#logind-check-graphical=false
+#logind-check-graphical=true
 #log-directory=/var/log/lightdm
 #run-directory=/var/run/lightdm
 #cache-directory=/var/cache/lightdm

--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -812,6 +812,8 @@ main (int argc, char **argv)
     }
     if (!config_has_key (config_get_instance (), "XDMCPServer", "hostname"))
         config_set_string (config_get_instance (), "XDMCPServer", "hostname", g_get_host_name ());
+    if (!config_has_key (config_get_instance (), "LightDM", "logind-check-graphical"))
+        config_set_string (config_get_instance (), "LightDM", "logind-check-graphical", TRUE);
 
     /* Override defaults */
     if (log_dir)


### PR DESCRIPTION
There is a possible race condition where lightdm fails to a black screen/tty, if lightdm loads faster than the system graphics driver. There is already the setting `logind-check-graphical` but it is unset per default.
As more and more people run into this pitfail, this PR sets `logind-check-graphical=True`.

**References**
https://wiki.archlinux.org/title/LightDM#LightDM_does_not_appear_or_monitor_only_displays_TTY_output
https://www.reddit.com/r/linuxmasterrace/comments/p9ebi0/logindcheckgraphicaltrue/
https://askubuntu.com/questions/1360285/login-screen-issue-first-lightdm-needs-to-be-killed-to-get-x-session-to-work
https://github.com/canonical/lightdm/issues/165
