### PR TITLE
Fix for other libcs

### DIFF
--- a/liblightdm-gobject/language.c
+++ b/liblightdm-gobject/language.c
@@ -210,6 +210,7 @@ lightdm_language_get_name (LightDMLanguage *language)
 
     if (!priv->name)
     {
+#if HAVE_LC_IDENTIFICATION
         g_autofree gchar *locale = get_locale_name (priv->code);
         if (locale)
         {
@@ -223,6 +224,7 @@ lightdm_language_get_name (LightDMLanguage *language)
 
             setlocale (LC_ALL, current);
         }
+#endif
         if (!priv->name)
         {
             g_auto(GStrv) tokens = g_strsplit_set (priv->code, "_.@", 2);
@@ -250,6 +252,7 @@ lightdm_language_get_territory (LightDMLanguage *language)
 
     if (!priv->territory && strchr (priv->code, '_'))
     {
+#if HAVE_LC_IDENTIFICATION
         g_autofree gchar *locale = get_locale_name (priv->code);
         if (locale)
         {
@@ -263,6 +266,7 @@ lightdm_language_get_territory (LightDMLanguage *language)
 
             setlocale (LC_ALL, current);
         }
+#endif
         if (!priv->territory)
         {
             g_auto(GStrv) tokens = g_strsplit_set (priv->code, "_.@", 3);

--- a/src/session-child.c
+++ b/src/session-child.c
@@ -194,8 +194,13 @@ read_xauth (void)
 }
 
 /* GNU provides this but we can't rely on that so let's make our own version */
+#if defined(__GLIBC__)
 static void
 updwtmpx (const gchar *wtmp_file, struct utmpx *ut)
+#else // use this version in libc's other than glibc
+void
+updwtmpx (const char *wtmp_file, const struct utmpx *ut)
+#endif
 {
     struct utmp u;
     memset (&u, 0, sizeof (u));

--- a/tests/src/libsystem.c
+++ b/tests/src/libsystem.c
@@ -222,7 +222,7 @@ redirect_path (const gchar *path)
     return g_strdup (path);
 }
 
-#ifdef __linux__
+#ifdef __GLIBC__
 static int
 open_wrapper (const char *func, const char *pathname, int flags, mode_t mode)
 {


### PR DESCRIPTION
I came across these two issues while trying to build lightdm on musl libc. Some of the patches are based on other Linux distro's patches (for example Alpine and Void).

The second commit where I do `ifdef __GLIBC__` can be done in a better way, I'm hoping someone can help me figure that out.