### PR TITLE
Fix SC2166 and remove `` bashism

### DIFF
--- a/debian/lightdm-greeter-session
+++ b/debian/lightdm-greeter-session
@@ -28,7 +28,7 @@ cleanup()
     exit 0
 }
 
-[ -n "$DBUS_SESSION_BUS_ADDRESS" ] || eval `dbus-launch --sh-syntax`
+[ -n "$DBUS_SESSION_BUS_ADDRESS" ] || eval $(dbus-launch --sh-syntax)
 
 exec $@ &
 CMD_PID=$!

--- a/debian/lightdm-session
+++ b/debian/lightdm-session
@@ -62,7 +62,7 @@ if type setxkbmap >/dev/null 2>&1; then
     for file in "/etc/X11/Xkbmap" "$HOME/.Xkbmap"; do
         if [ -f "$file" ]; then
             echo "Loading keymap: $file"
-            setxkbmap `cat "$file"`
+            setxkbmap $(cat "$file")
             XKB_IN_USE=yes
         fi
     done
@@ -103,7 +103,7 @@ USERXSESSIONRC=$HOME/.xsessionrc
 ALTUSERXSESSION=$HOME/.Xsession
 
 if [ -d "$xsessionddir" ]; then
-    for i in `ls $xsessionddir`; do
+    for i in $(ls $xsessionddir); do
         script="$xsessionddir/$i"
         echo "Loading X session script $script"
         if [ -r "$script" ] && [ -f "$script" ] && expr "$i" : '^[[:alnum:]_-]\+$' > /dev/null; then

--- a/debian/lightdm-session
+++ b/debian/lightdm-session
@@ -87,7 +87,7 @@ xinitdir="/etc/X11/xinit/xinitrc.d"
 if [ -d "$xinitdir" ]; then
     for script in $xinitdir/*; do
         echo "Loading xinit script $script"
-        if [ -x "$script" -a ! -d "$script" ]; then
+        if [ -x "$script" ] && [ ! -d "$script" ]; then
             . "$script"
         fi
     done
@@ -106,7 +106,7 @@ if [ -d "$xsessionddir" ]; then
     for i in `ls $xsessionddir`; do
         script="$xsessionddir/$i"
         echo "Loading X session script $script"
-        if [ -r "$script"  -a -f "$script" ] && expr "$i" : '^[[:alnum:]_-]\+$' > /dev/null; then
+        if [ -r "$script" ] && [ -f "$script" ] && expr "$i" : '^[[:alnum:]_-]\+$' > /dev/null; then
             . "$script"
         fi
     done

--- a/debian/lightdm.config
+++ b/debian/lightdm.config
@@ -48,7 +48,7 @@ fi
 # lightdm, otherwise ask
 
 # GDM transition: When upgrading from an old version, don't ask the question.
-if [ -z "$2" -a -n "$RELEASE_UPGRADE_IN_PROGRESS" ]; then
+if [ -z "$2" ] && [ -n "$RELEASE_UPGRADE_IN_PROGRESS" ]; then
     db_set shared/default-x-display-manager lightdm
     db_fset shared/default-x-display-manager seen true
 elif ! dpkg --compare-versions "$2" lt-nl "1.22.0-0ubuntu6~"; then

--- a/debian/lightdm.init
+++ b/debian/lightdm.init
@@ -61,7 +61,8 @@ case "$1" in
   start)
     if [ "$HEED_DEFAULT_DISPLAY_MANAGER" = "true" ] &&
        [ -e $DEFAULT_DISPLAY_MANAGER_FILE ] &&
-       [ "$(cat $DEFAULT_DISPLAY_MANAGER_FILE)" != "/usr/bin/lightdm" -a "$(cat $DEFAULT_DISPLAY_MANAGER_FILE)" != "/usr/sbin/lightdm" ]; then
+       [ "$(cat $DEFAULT_DISPLAY_MANAGER_FILE)" != "/usr/bin/lightdm" ] &&
+	   [ "$(cat $DEFAULT_DISPLAY_MANAGER_FILE)" != "/usr/sbin/lightdm" ]; then
       echo "Not starting X display manager (lightdm); it is not the default" \
         "display manager."
     else


### PR DESCRIPTION
- According to [SC2166](https://github.com/koalaman/shellcheck/wiki/SC2166), `[ p ] && [ q ]` should to preferred to `[ p -a q ]` as the latter "is not well defined"
- using <code>``</code> instead of `$()` for command substitution is a bashism (and is deprecated in bash) so it shouldn't be used in scripts starting with <code>#!/bin/sh</code>