### PR TITLE
dm-tool: Drop mentions of `add-seat`

### DIFF
--- a/data/bash-completion/dm-tool
+++ b/data/bash-completion/dm-tool
@@ -4,7 +4,7 @@ _dm_tool()
 {
     local cur prev opts
     _init_completion || return
-    opts='switch-to-greeter switch-to-user switch-to-guest lock list-seats add-nested-seat add-local-x-seat add-seat'
+    opts='switch-to-greeter switch-to-user switch-to-guest lock list-seats add-nested-seat add-local-x-seat'
 
     case "$prev" in
     switch-to-greeter)
@@ -29,10 +29,6 @@ _dm_tool()
         return 0
         ;;
     add-local-x-seat)
-        # FIXME ...
-        return 0
-        ;;
-    add-seat)
         # FIXME ...
         return 0
         ;;

--- a/data/dm-tool.1
+++ b/data/dm-tool.1
@@ -55,9 +55,6 @@ Start an X server inside a session and connect it to a display manager.
 .TP
 .B add-local-x-seat DISPLAY_NUMBER
 Connect an existing X server to the display manager.
-.TP
-.B add-seat TYPE [NAME=VALUE...]
-Add a dynamic seat.
 .SH ENVIRONMENT
 .TP
 .B XDG_SEAT_PATH

--- a/src/dm-tool.c
+++ b/src/dm-tool.c
@@ -129,8 +129,7 @@ main (int argc, char **argv)
                         "  lock                                                 Lock the current seat\n"
                         "  list-seats                                           List the active seats\n"
                         "  add-nested-seat [--fullscreen|--screen DIMENSIONS]   Start a nested display\n"
-                        "  add-local-x-seat DISPLAY_NUMBER                      Add a local X seat\n"
-                        "  add-seat TYPE [NAME=VALUE...]                        Add a dynamic seat\n");
+                        "  add-local-x-seat DISPLAY_NUMBER                      Add a local X seat\n");
             return EXIT_SUCCESS;
         }
         else if (strcmp (arg, "-v") == 0 || strcmp (arg, "--version") == 0)


### PR DESCRIPTION
This command is deprecated and isn't well-documented anyway. Close #279.