### PR TITLE
Add dependabot for dependency Management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot is a tool to [Monitor and create PRs for outdated dependencies](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates).

This PR only contains a basic configuration for daily checks but it can be a great tool to not have to manually handle dependencies.