### PR TITLE
data/apparmor/lightdm-guest-session.in: Allow l operation on /run/use…

### DIFF
--- a/data/apparmor/lightdm-guest-session.in
+++ b/data/apparmor/lightdm-guest-session.in
@@ -18,6 +18,7 @@
   /usr/bin/sogou-qimpanel-watchdog ix,
   /usr/bin/sogou-sys-notify ix,
   /tmp/sogou-qimpanel:* rwl,
+  /run/user/*/ICEauthority-l l,
 
   # Allow ibus
   unix (bind, listen) type=stream addr="@tmp/ibus/*",


### PR DESCRIPTION
…r/*/ICEauthority-l.

 This resolves long login delays into X11 guest sessions when using
 Arctica Greeter (forked from Unity Greeter). While waiting for the
 desktop to appear, the screen stays black and a non-WM'ed dialog box
 appears on screen, saying: "Could not update ICEauthority file
 /run/user/<guest-uid>/ICEauthority".

 When testing with MATE desktop, apparmor denies esp. creating this link
 operation:
 operation="link" class="file" profile="<path-to>/lightdm-guest-session"
 name="/run/user/997/ICEauthority-l" pid=<pid> comm="mate-session"
 requested_mask="l" denied_mask="l" fsuid=<fsuid> ouid=<ouid>
 target="/run/user/<uidnumber>/ICEauthority-c"

 Similar in Xfce4:
 operation="link" class="file" profile="<path-to>/lightdm-guest-session"
 name="/run/user/997/ICEauthority-l" pid=<pid> comm="iceauth"
 requested_mask="l" denied_mask="l" fsuid=<fsuid> ouid=<ouid>
 target="/run/user/<uidnumber>/ICEauthority-c"