### PR TITLE
fix(login)

### DIFF
--- a/src/session-child.c
+++ b/src/session-child.c
@@ -603,8 +603,13 @@ session_child_run (int argc, char **argv)
     if (x_authority)
     {
         gboolean drop_privileges = geteuid () == 0;
-        if (drop_privileges)
+        if (drop_privileges) {
+            if (x_authority_filename && chown (x_authority_filename, user_get_uid (user), user_get_gid (user)) < 0)
+                g_warning ("Failed to set ownership of user authority file: %s", strerror (errno));
             privileges_drop (user_get_uid (user), user_get_gid (user));
+            if (x_authority_filename && chmod (x_authority_filename, S_IRUSR | S_IWUSR) < 0)
+                g_warning ("Failed to set access of user authority file: %s", strerror (errno));
+        }
 
         g_autoptr(GError) error = NULL;
         gboolean result = x_authority_write (x_authority, XAUTH_WRITE_MODE_REPLACE, x_authority_filename, &error);

--- a/src/x-authority.c
+++ b/src/x-authority.c
@@ -294,7 +294,8 @@ x_authority_write (XAuthority *auth, XAuthWriteMode mode, const gchar *filename,
         if (!matched &&
             priv->family == a_priv->family &&
             address_matches &&
-            strcmp (priv->number, a_priv->number) == 0)
+            strcmp (priv->number, a_priv->number) == 0 &&
+            strcmp (priv->authorization_name, a_priv->authorization_name) == 0)
         {
             matched = TRUE;
             if (mode == XAUTH_WRITE_MODE_REMOVE)


### PR DESCRIPTION
Fixed User desktop login failure after the.Xauthority file permission or authname is modified

Description: 修复用户的.Xauthority文件权限或authname被修改后无法登录用户桌面问题

Log: null