### PR TITLE
Fixed the issue that tty information would not be written to utmp whe…

### DIFF
--- a/src/wayland-session.c
+++ b/src/wayland-session.c
@@ -65,6 +65,10 @@ wayland_session_connect_session (DisplayServer *display_server, Session *session
     {
         g_autofree gchar *value = g_strdup_printf ("%d", priv->vt);
         session_set_env (session, "XDG_VTNR", value);
+
+        g_autofree gchar *tty_text = NULL;
+        tty_text = g_strdup_printf("/dev/tty/%d",priv->vt);
+        session_set_tty(session,tty_text);
     }
 }
 


### PR DESCRIPTION
…n logging in to a Wayland session