### PR TITLE
Make location of .xession-errors depend on user configuration

### DIFF
--- a/common/configuration.c
+++ b/common/configuration.c
@@ -346,6 +346,7 @@ config_init (Configuration *config)
     g_hash_table_insert (config->priv->lightdm_keys, "greeters-directory", GINT_TO_POINTER (KEY_SUPPORTED));
     g_hash_table_insert (config->priv->lightdm_keys, "backup-logs", GINT_TO_POINTER (KEY_SUPPORTED));
     g_hash_table_insert (config->priv->lightdm_keys, "dbus-service", GINT_TO_POINTER (KEY_SUPPORTED));
+    g_hash_table_insert (config->priv->lightdm_keys, "smart-xsession-errors", GINT_TO_POINTER (KEY_SUPPORTED));
     g_hash_table_insert (config->priv->lightdm_keys, "logind-load-seats", GINT_TO_POINTER (KEY_DEPRECATED));
 
     g_hash_table_insert (config->priv->seat_keys, "type", GINT_TO_POINTER (KEY_SUPPORTED));

--- a/data/lightdm.conf
+++ b/data/lightdm.conf
@@ -17,6 +17,8 @@
 # greeters-directory = Directory to find greeters
 # backup-logs = True to move add a .old suffix to old log files when opening new ones
 # dbus-service = True if LightDM provides a D-Bus service to control it
+# smart-xsession-errors = True to force .xsesion.errors file to be positioned according to XDG standards
+#                              Default False, put it in ~/.xsession-errors
 #
 [LightDM]
 #start-default-seat=true
@@ -35,6 +37,7 @@
 #greeters-directory=$XDG_DATA_DIRS/lightdm/greeters:$XDG_DATA_DIRS/xgreeters
 #backup-logs=true
 #dbus-service=true
+#smart-xsession-errors=false
 
 #
 # Seat configuration

--- a/src/lightdm.c
+++ b/src/lightdm.c
@@ -771,6 +771,8 @@ main (int argc, char **argv)
         config_set_boolean (config_get_instance (), "LightDM", "backup-logs", TRUE);
     if (!config_has_key (config_get_instance (), "LightDM", "dbus-service"))
         config_set_boolean (config_get_instance (), "LightDM", "dbus-service", TRUE);
+    if (!config_has_key (config_get_instance (), "LightDM", "smart-xsession-errors"))
+        config_set_boolean (config_get_instance (), "LightDM", "smart-xsession-errors", FALSE);
     if (!config_has_key (config_get_instance (), "Seat:*", "type"))
         config_set_string (config_get_instance (), "Seat:*", "type", "local");
     if (!config_has_key (config_get_instance (), "Seat:*", "pam-service"))

--- a/src/session.c
+++ b/src/session.c
@@ -981,7 +981,17 @@ session_init (Session *session)
 {
     SessionPrivate *priv = session_get_instance_private (session);
 
-    priv->log_filename = g_strdup (".xsession-errors");
+    if(config_get_boolean (config_get_instance (), "LightDM", "smart-xsession-errors")) {
+        if (g_getenv ("XDG_STATE_HOME")) {
+            priv->log_filename = g_build_filename (g_getenv ("XDG_STATE_HOME"), ".xsession-errors", NULL);
+        } else if (g_getenv ("XDG_CACHE_HOME")) {
+            priv->log_filename = g_build_filename (g_getenv ("XDG_CACHE_HOME"), ".xsession-errors", NULL);
+        } else {
+            priv->log_filename = g_build_filename (".cache", ".xsession-errors", NULL);
+        }
+    } else {
+        priv->log_filename = g_strdup (".xsession-errors");
+    }
     priv->log_mode = LOG_MODE_BACKUP_AND_TRUNCATE;
     priv->to_child_input = -1;
     priv->from_child_output = -1;


### PR DESCRIPTION
I have extended on the patch in #287 by adding a configuration file variable for lightdm to control how the location of `.xsession-errors` is chosen.

I added a `smart-xsession-errors`, which is off by default, that allows to switch from the old behavior (putting it in `~/.xsession-errors`) to the algorith suggested in #287

This patch is being considered for inclusion in the freebsd ports tree for lightdm [1]. I decided to add a configuration variable and set it to false (implying old behavior), because I don't feel comfortable forcing a change of the location of this file on users. This due to the fact that the location of this file is historical behavior and expected by the users.

[1] https://bugs.freebsd.org/266532 and https://bugs.freebsd.org/275885