### PR TITLE
modify control value of pam_systemd

### DIFF
--- a/data/pam/lightdm
+++ b/data/pam/lightdm
@@ -17,4 +17,4 @@ password  required pam_unix.so
 
 # Setup session
 session   required pam_unix.so
-session   optional pam_systemd.so
+session   required pam_systemd.so


### PR DESCRIPTION
I am debugging a display session related issue.
The scene is as follow:
1) Type in username and password
2) Lightdm greeter session starts and pam_systemd.so is called
3) pam_systemd.so returns with some err code, then the X session can not run

I guess the control value of pam_systemd.so shall be modified as “required”， and which shall result lightdm fail, and lightdm has chance to be restarted automatically by systemd.

Could U help to review this PR? Thanks